### PR TITLE
Switch to v2 credential context

### DIFF
--- a/did-api-gateway/did_vc_api.py
+++ b/did-api-gateway/did_vc_api.py
@@ -218,7 +218,7 @@ def create_vc(req: VCCreateRequest, x_api_key: str = Header(...)):
     firmware_hash = hashlib.sha256(firmware_bytes).hexdigest()
 
     vc = {
-        "@context": ["https://www.w3.org/2018/credentials/v1"],
+        "@context": ["https://www.w3.org/ns/credentials/v2"],
         "type": ["VerifiableCredential", "FirmwareCredential"],
         "id": f"vc:{did_name}:{firmware_version}",
         "issuer": f"did:local:{did_name}",
@@ -274,7 +274,7 @@ def create_vp(req: VPCreateRequest, x_api_key: str = Header(...)):
         vc = json.load(f)
 
     vp = {
-        "@context": ["https://www.w3.org/2018/credentials/v1"],
+        "@context": ["https://www.w3.org/ns/credentials/v2"],
         "type": ["VerifiablePresentation"],
         "verifiableCredential": [vc],
         "holder": f"did:local:{did_name}"

--- a/did-api-vendor/backend/main.py
+++ b/did-api-vendor/backend/main.py
@@ -204,7 +204,7 @@ def vp_create(req: VPCreateRequest, x_api_key: str = Header(...)):
         vc = json.load(f)
 
     vp = {
-        "@context": ["https://www.w3.org/2018/credentials/v1"],
+        "@context": ["https://www.w3.org/ns/credentials/v2"],
         "type": ["VerifiablePresentation"],
         "verifiableCredential": [vc],
         "holder": f"did:local:{did_name}"

--- a/did-api-vendor/backend/vc_utils.py
+++ b/did-api-vendor/backend/vc_utils.py
@@ -125,7 +125,7 @@ def issue_vc(did_name: str, firmware_version: str, device_model: str, firmware_b
     private_key, pubkey_pem = load_or_create_keys(did_name)
 
     vc = {
-        "@context": ["https://www.w3.org/2018/credentials/v1"],
+        "@context": ["https://www.w3.org/ns/credentials/v2"],
         "type": ["VerifiableCredential", "FirmwareCredential"],
         "id": f"vc:{did_name}:{firmware_version}",
         "issuer": f"did:local:{did_name}",

--- a/did-iot-firmware/esp32_fw.ino
+++ b/did-iot-firmware/esp32_fw.ino
@@ -301,7 +301,7 @@ void verifyVC() {
 
   String vpPayload = "{"
     "\"vp\":{"
-      "\"@context\": [\"https://www.w3.org/2018/credentials/v1\"],"
+      "\"@context\": [\"https://www.w3.org/ns/credentials/v2\"],"
       "\"type\": [\"VerifiablePresentation\"],"
       "\"holder\": \"did:local:esp32-device\","
       "\"verifiableCredential\": [" + vcOnly + "]"


### PR DESCRIPTION
## Summary
- update credential context URLs to `https://www.w3.org/ns/credentials/v2`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6864e5c4ee048326891826b29d8927c3