### PR TITLE
Remove comments

### DIFF
--- a/did-iot-firmware/esp32_fw.ino
+++ b/did-iot-firmware/esp32_fw.ino
@@ -8,7 +8,7 @@
 #include "mbedtls/sha256.h"
 #define VERIFY_SIGNATURE 0
 #if VERIFY_SIGNATURE
-#include "dilithium.h" // lightweight Dilithium implementation
+#include "dilithium.h"
 #endif
 
 const char* apSSID = "ESP32-VC-Uploader";
@@ -133,7 +133,7 @@ bool verifySignature(const JsonDocument& doc) {
   String canonical;
   canonicalize(tmp.as<JsonVariant>(), canonical);
 
-  uint8_t sig[3300]; // size sufficient for Dilithium2
+  uint8_t sig[3300];
   size_t sigLen = decodeBase64Url(sigB64, sig);
   uint8_t pub[1312];
   size_t pubLen = decodeBase64(pkB64, strlen(pkB64), pub);

--- a/pqcrypto/sign/dilithium2.py
+++ b/pqcrypto/sign/dilithium2.py
@@ -1,8 +1,6 @@
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
 from cryptography.hazmat.primitives import serialization
 
-# Simple stub implementation using Ed25519 for tests
-
 def generate_keypair():
     priv = Ed25519PrivateKey.generate()
     pub = priv.public_key()


### PR DESCRIPTION
## Summary
- remove comments in pqcrypto dilithium stub
- remove comment markers from ESP32 firmware

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi, pqcrypto)*

------
https://chatgpt.com/codex/tasks/task_e_6866102bfa4c8326a43e44d2bb157ee4